### PR TITLE
Model properties, indexing, and validations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,8 @@ AllCops:
   Exclude:
     - 'spec/internal_test_hyrax/**/*'
     - 'vendor/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/hyrax/doi/spec/shared_specs/*'
+    - 'spec/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -762,6 +762,8 @@ GEM
       rdf-xsd (~> 3.1)
       sparql (~> 3.1)
       sxp (~> 1.1)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     signet (0.14.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -875,6 +877,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers
   simplecov (= 0.17.1, < 0.18)
   solr_wrapper (>= 0.3)
   spring

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hyrax::Doi
+# Hyrax::DOI
 Code: [![CircleCI](https://circleci.com/gh/ubiquitypress/hyrax-doi.svg?style=svg)](https://circleci.com/gh/ubiquitypress/hyrax-doi)
 [![Code Climate](https://codeclimate.com/github/ubiquitypress/hyrax-doi/badges/gpa.svg)](https://codeclimate.com/github/ubiquitypress/hyrax-doi)
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'rdoc/task'
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Hyrax::Doi'
+  rdoc.title    = 'Hyrax::DOI'
   rdoc.options << '--line-numbers'
   rdoc.rdoc_files.include('README.md')
   rdoc.rdoc_files.include('lib/**/*.rb')

--- a/app/controllers/hyrax/doi/application_controller.rb
+++ b/app/controllers/hyrax/doi/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     class ApplicationController < ActionController::Base
       protect_from_forgery with: :exception
     end

--- a/app/helpers/hyrax/doi/application_helper.rb
+++ b/app/helpers/hyrax/doi/application_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     module ApplicationHelper
     end
   end

--- a/app/jobs/hyrax/doi/application_job.rb
+++ b/app/jobs/hyrax/doi/application_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     class ApplicationJob < ActiveJob::Base
     end
   end

--- a/app/mailers/hyrax/doi/application_mailer.rb
+++ b/app/mailers/hyrax/doi/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     class ApplicationMailer < ActionMailer::Base
       default from: 'from@example.com'
       layout 'mailer'

--- a/app/models/concerns/hyrax/doi/doi_behavior.rb
+++ b/app/models/concerns/hyrax/doi/doi_behavior.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Hyrax
+  module DOI
+    module DOIBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        property :doi, predicate: ::RDF::Vocab::BIBO.doi, multiple: false do |index|
+          index.as :stored_sortable
+        end
+        property :doi_status_when_public, predicate: ::RDF::URI('http://samvera.org/ns/hyrax/doi#doi_status_when_public'), multiple: false do |index|
+          index.as :stored_sortable
+        end
+
+        validates :doi, format: { with: /\A10\.\d{4,}(\.\d+)*\/[-._;():\/A-Za-z\d]+\z/ }, allow_nil: true
+        # TODO: turn controlled vocab here into a frozen constant to allow for extensions and reuse
+        validates :doi_status_when_public, inclusion: { in: [:draft, :registered, :findable] }, allow_nil: true
+      end
+    end
+  end
+end

--- a/app/models/hyrax/doi/application_record.rb
+++ b/app/models/hyrax/doi/application_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     class ApplicationRecord < ActiveRecord::Base
       self.abstract_class = true
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-Hyrax::Doi::Engine.routes.draw do
+Hyrax::DOI::Engine.routes.draw do
 end

--- a/hyrax-doi.gemspec
+++ b/hyrax-doi.gemspec
@@ -7,7 +7,7 @@ require "hyrax/doi/version"
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
   spec.name        = "hyrax-doi"
-  spec.version     = Hyrax::Doi::VERSION
+  spec.version     = Hyrax::DOI::VERSION
   spec.authors     = ["Chris Colvard"]
   spec.email       = ["chris.colvard@gmail.com"]
   spec.homepage    = ""

--- a/hyrax-doi.gemspec
+++ b/hyrax-doi.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "rspec-rails"
+  spec.add_development_dependency 'shoulda-matchers'
   # Workaround for cc-test-reporter with SimpleCov 0.18.
   # Stop upgrading SimpleCov until the following issue will be resolved.
   # https://github.com/codeclimate/test-reporter/issues/418

--- a/lib/hyrax/doi.rb
+++ b/lib/hyrax/doi.rb
@@ -2,7 +2,7 @@
 require "hyrax/doi/engine"
 
 module Hyrax
-  module Doi
+  module DOI
     # Your code goes here...
   end
 end

--- a/lib/hyrax/doi/engine.rb
+++ b/lib/hyrax/doi/engine.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     class Engine < ::Rails::Engine
-      isolate_namespace Hyrax::Doi
+      isolate_namespace Hyrax::DOI
     end
   end
 end

--- a/lib/hyrax/doi/spec/shared_specs.rb
+++ b/lib/hyrax/doi/spec/shared_specs.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require 'hyrax/doi/spec/shared_specs/doi_behavior'

--- a/lib/hyrax/doi/spec/shared_specs/doi_behavior.rb
+++ b/lib/hyrax/doi/spec/shared_specs/doi_behavior.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+RSpec.shared_examples "a DOI-enabled model" do
+  subject { work }
+
+  let(:properties) do
+    [:doi,
+     :doi_status_when_public]
+  end
+
+  describe "properties" do
+    it "has DOI properties" do
+      properties.each do |property|
+        expect(subject).to respond_to(property)
+      end
+    end
+  end
+
+  describe 'validations' do
+    describe 'validates format of doi' do
+      let(:valid_dois) { [nil, '10.1234/abc', '10.1234.100/abc-def', '10.1234/1', '10.1234/doi/with/more/slashes'] }
+      let(:invalid_dois) { ['10.123/abc', 'https://doi.org/10.1234/abc', '10.1234/abc def', ''] }
+
+      it 'accepts valid dois' do
+        valid_dois.each do |valid_doi|
+          expect(subject).to allow_value(valid_doi).for(:doi)
+        end
+      end
+
+      it 'rejects invalid dois' do
+        invalid_dois.each do |invalid_doi|
+          expect(subject).not_to allow_values(invalid_doi).for(:doi)
+        end
+      end
+    end
+
+    it 'validates inclusion of doi_status_when_public' do
+      expect(subject).to validate_inclusion_of(:doi_status_when_public).in_array([nil, :draft, :registered, :findable]).allow_nil
+    end
+  end
+
+  describe 'to_solr' do
+    let(:solr_doc) { subject.to_solr }
+
+    let(:solr_fields) do
+      [:doi_ssi,
+       :doi_status_when_public_ssi]
+    end
+
+    before do
+      work.doi = "10.1234/abc"
+      work.doi_status_when_public = :draft
+    end
+
+    it 'has solr fields' do
+      solr_fields.each do |field|
+        expect(solr_doc.fetch(field.to_s)).not_to be_blank
+      end
+    end
+  end
+end

--- a/lib/hyrax/doi/version.rb
+++ b/lib/hyrax/doi/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  module Doi
+  module DOI
     VERSION = '0.1.0'
   end
 end

--- a/spec/models/concerns/doi_behavior_spec.rb
+++ b/spec/models/concerns/doi_behavior_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hyrax/doi/spec/shared_specs'
+
+describe 'Hyrax::DOI::DOIBehavior' do
+  let(:model_class) do
+    Class.new(GenericWork) do
+      include Hyrax::DOI::DOIBehavior
+
+      # Defined here for ActiveModel::Validations error messages
+      def self.name
+        "WorkWithDOI"
+      end
+    end
+  end
+  let(:work) { model_class.new(title: ['Moomin']) }
+
+  it_behaves_like 'a DOI-enabled model'
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,14 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
+require 'shoulda-matchers'
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -32,6 +40,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Also in this PR: uppercase DOI in the namespacing.

Two properties added to the model:
- doi - holds the DOI, multiple: false, nil allowed, indexed as `doi_ssi`, and validated as matching the DOI format (10.NNNN/xxxxxx)
- doi_status_when_public - saves the eventual status the DOI should have when the work becomes public, multiple: false, nil allowed, indexed as `doi_status_when_public_ssi`, and validated as being either nil, :draft, :registered, or :findable

I made up a placeholder RDF predicate for doi_status_when_public which might need to be changed but which probably won't be able to come from any standard RDF vocabulary.

Also note that currently doi_status_when_public is DataCite specific but could be changed later to also support CrossRef's pending publications.