### PR TITLE
Generator for setting up DOI support for a given work type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   DisplayCopNames: true
   Exclude:
     - 'spec/internal_test_hyrax/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
 
 Metrics/BlockLength:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     almond-rails (0.3.0)
       rails (>= 4.2)
+    ammeter (1.1.4)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-rails (>= 2.2)
     arel (9.0.0)
     ast (2.4.1)
     autoprefixer-rails (9.8.4)
@@ -854,6 +858,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ammeter
   bixby
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Hyrax-doi is a Hyrax plugin that provides tools for working with DOIs including 
 ## Compatibilty
 Hyrax-doi is compatible with Hyrax 2.8+ and tested with a [Hyrax 2.8.0 test application](https://github.com/ubiquitypress/hyrax_test_app) that mirrors the generated app used by Hyrax internally for testing.
 
-## Usage
-TODO
-
 ## Installation
 Add this line to your application's Gemfile:
 
@@ -31,6 +28,14 @@ $ bundle
 Or install it yourself as:
 ```bash
 $ gem install hyrax-doi
+```
+
+## Usage
+
+### Setup work type for hyrax-doi
+Run the generator to add DOI support to a given work type:
+```
+rails g hyrax:doi:add_to_work_type MyWorkType
 ```
 
 ## Development

--- a/app/models/concerns/hyrax/doi/doi_behavior.rb
+++ b/app/models/concerns/hyrax/doi/doi_behavior.rb
@@ -12,6 +12,7 @@ module Hyrax
           index.as :stored_sortable
         end
 
+        # TODO: Add a more helpful error message
         validates :doi, format: { with: /\A10\.\d{4,}(\.\d+)*\/[-._;():\/A-Za-z\d]+\z/ }, allow_nil: true
         # TODO: turn controlled vocab here into a frozen constant to allow for extensions and reuse
         validates :doi_status_when_public, inclusion: { in: [:draft, :registered, :findable] }, allow_nil: true

--- a/hyrax-doi.gemspec
+++ b/hyrax-doi.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "~> 5.2.4", ">= 5.2.4.3"
   spec.add_dependency "hyrax", "~> 2.8"
 
+  spec.add_development_dependency 'ammeter'
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pg"
   spec.add_development_dependency 'rspec_junit_formatter'

--- a/lib/generators/hyrax/doi/add_to_work_type_generator.rb
+++ b/lib/generators/hyrax/doi/add_to_work_type_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails/generators'
+require 'rails/generators/model_helpers'
+
+module Hyrax
+  module DOI
+    class AddToWorkTypeGenerator < Rails::Generators::NamedBase
+      # ActiveSupport can interpret models as plural which causes
+      # counter-intuitive route paths. Pull in ModelHelpers from
+      # Rails which warns users about pluralization when generating
+      # new models or scaffolds.
+      include Rails::Generators::ModelHelpers
+
+      # Required due to non-standard capitalization of DOI namespace
+      namespace 'hyrax:doi:add_to_work_type'
+      # Same as adding --skip-namespace flag to generator call
+      # This removes the hyrax/doi namespace from class_path
+      # Namespaces passed as the argument will still appear in class_path
+      class_option :skip_namespace, default: true
+
+      desc "Add DOI support to given work type"
+
+      def inject_into_model
+        # For some reason I had to use self.destination_root here to get all contexts to work (calling from hyrax app, calling from this engine to test app, rspec tests)
+        # rubocop:disable Style/RedundantSelf
+        self.destination_root = Rails.root if self.destination_root.blank? || self.destination_root == Hyrax::DOI::Engine.root.to_s
+        model_file = File.join(self.destination_root, 'app', 'models', *class_path, "#{file_name}.rb")
+        # rubocop:enable Style/RedundantSelf
+
+        insert_into_file model_file, after: 'include ::Hyrax::WorkBehavior' do
+          "\n" \
+          "  # Adds behaviors for hyrax-doi plugin.\n" \
+          "  include Hyrax::DOI::DOIBehavior"
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/add_to_work_type_generator_spec.rb
+++ b/spec/generators/add_to_work_type_generator_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+# Generators are not automatically loaded by Rails
+require 'generators/hyrax/doi/add_to_work_type_generator'
+
+def model_path
+  File.join('app', 'models', "#{klass.underscore}.rb")
+end
+
+describe Hyrax::DOI::AddToWorkTypeGenerator, type: :generator do
+  # Tell the generator where to put its output (what it thinks of as Rails.root)
+  destination Hyrax::DOI::Engine.root.join("tmp", "generator_testing")
+  before do
+    # This will wipe the destination root dir
+    prepare_destination
+
+    # Setup work type files in generator testing destination root dir
+    FileUtils.mkdir_p destination_root.join(File.dirname(model_path))
+    FileUtils.cp Rails.root.join(model_path), destination_root.join(model_path)
+  end
+
+  let(:klass) { 'GenericWork' }
+
+  it 'adds behavior module to model class' do
+    run_generator [klass]
+    expect(file(model_path)).to contain('include Hyrax::DOI::DOIBehavior')
+  end
+
+  context 'with a namespaced model class' do
+    let(:klass) { 'NamespacedWorks::NestedWork' }
+
+    it 'adds behavior module tod model class' do
+      run_generator [klass]
+      expect(file(model_path)).to contain('include Hyrax::DOI::DOIBehavior')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require File.expand_path('internal_test_hyrax/config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+# For testing generators
+require 'ammeter/init'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
This generator can be used to inject modules into the work type classes.  Currently only the model exists so the generator only injects into it for now.

This generator is run for a single work type:
```
rails g hyrax:doi:add_to_work_type MyWorkType
```

The generator is being tested using `ammeter` (also used by `rspec-rails`) which is an rspec wrapper around `Rails::Generators::TestCase`.