### PR TITLE
Fix camelizing namespace

### DIFF
--- a/lib/hyrax/doi/engine.rb
+++ b/lib/hyrax/doi/engine.rb
@@ -3,6 +3,14 @@ module Hyrax
   module DOI
     class Engine < ::Rails::Engine
       isolate_namespace Hyrax::DOI
+
+      config.before_configuration do
+        # Fix camelizing of paths for autoloading
+        # With this hyrax/doi/application_helper -> Hyrax::DOI::ApplicationHelper
+        ActiveSupport::Inflector.inflections(:en) do |inflect|
+          inflect.acronym 'DOI'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Without this change hyrax/doi/application_helper was Hyrax::Doi::ApplicationHelper and
now it correctly resolves to Hyrax::DOI::ApplicationHelper.

This fixes an issue on startup in production with helpers failing to autoload which stopped the boot process.