### PR TITLE
Initial implementation of a Datacite client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,10 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'hyrax-doi.gemspec'
     - 'lib/hyrax/doi/spec/shared_specs/*'
     - 'spec/**/*'
+
+Layout/LineLength:
+  Exclude:
+    - 'spec/support/datacite_api_stubs.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     csl (1.5.1)
       namae (~> 1.0)
@@ -370,6 +372,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashdiff (1.0.1)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http_logger (0.6.0)
@@ -814,6 +817,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
+    safe_yaml (1.0.5)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.4)
@@ -925,6 +929,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -973,6 +981,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   webdrivers (~> 4.0)
+  webmock
 
 BUNDLED WITH
    2.1.4

--- a/app/services/bolognese/readers/hyrax_work_reader.rb
+++ b/app/services/bolognese/readers/hyrax_work_reader.rb
@@ -25,7 +25,7 @@ module Bolognese
           # "id" => meta.fetch('id', nil),
           "identifiers" => parse_attributes(meta.fetch('identifier', nil)).to_s.strip.presence,
           "types" => read_hyrax_work_types(meta),
-          "doi" => normalize_doi(meta.fetch('doi', nil)),
+          "doi" => normalize_doi(meta.fetch('doi', nil)&.first),
           # "url" => normalize_id(meta.fetch("URL", nil)),
           "titles" => read_hyrax_work_titles(meta),
           "creators" => read_hyrax_work_creators(meta),

--- a/app/services/bolognese/writers/hyrax_work_writer.rb
+++ b/app/services/bolognese/writers/hyrax_work_writer.rb
@@ -39,7 +39,7 @@ module Bolognese
       end
 
       def build_hyrax_work_doi
-        doi.sub('https://doi.org/', '')
+        [doi.sub('https://doi.org/', '')]
       end
     end
   end

--- a/app/services/hyrax/doi/datacite_client.rb
+++ b/app/services/hyrax/doi/datacite_client.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+module Hyrax
+  module DOI
+    class DataciteClient
+      attr_reader :username, :password, :prefix, :mode
+
+      TEST_BASE_URL = "https://api.test.datacite.org/"
+      TEST_MDS_BASE_URL = "https://mds.test.datacite.org/"
+      PRODUCTION_BASE_URL = "https://api.datacite.org"
+      PRODUCTION_MDS_BASE_URL = "https://mds.datacite.org/"
+
+      def initialize(username:, password:, prefix:, mode: :production)
+        @username = username
+        @password = password
+        @prefix = prefix
+        @mode = mode
+      end
+
+      # Mint a draft DOI without metadata or a url
+      # If you already have a DOI and want to register it as a draft then go through the normal process (put_metadata/register_url)
+      def create_draft_doi
+        # Use regular api instead of mds for metadata-less url-less draft doi creation
+        response = connection.post('dois', draft_doi_payload.to_json, "Content-Type" => "application/json")
+        raise Error.new('Failed creating draft DOI', response) unless response.status == 201
+
+        JSON.parse(response.body)['data']['id']
+      end
+
+      def delete_draft_doi(doi)
+        response = mds_connection.delete("doi/#{doi}")
+        raise Error.new('Failed deleting draft DOI', response) unless response.status == 200
+
+        doi
+      end
+
+      def get_metadata(doi)
+        response = mds_connection.get("metadata/#{doi}")
+        raise Error.new('Failed getting DOI metadata', response) unless response.status == 200
+
+        Nokogiri::XML(response.body).remove_namespaces!
+      end
+
+      # This will mint a new draft DOI if the passed doi parameter is blank
+      # The passed datacite xml needs an identifier (just the prefix when minting new DOIs)
+      def put_metadata(doi, metadata)
+        doi = prefix if doi.blank?
+        response = mds_connection.put("metadata/#{doi}", metadata, { 'Content-Type': 'application/xml;charset=UTF-8' })
+        raise Error.new('Failed creating metadata for DOI', response) unless response.status == 201
+
+        /^OK \((?<found_or_created_doi>.*)\)$/ =~ response.body
+        found_or_created_doi
+      end
+
+      def get_url(doi)
+        response = mds_connection.get("doi/#{doi}")
+        raise Error.new('Failed getting DOI url', response) unless response.status == 200
+
+        response.body
+      end
+
+      # Beware: This will convert draft DOIs to findable!
+      # Metadata needs to be registered for a DOI before a url can be registered
+      def register_url(doi, url)
+        payload = "doi=#{doi}\nurl=#{url}"
+        response = mds_connection.put("doi/#{doi}", payload, { 'Content-Type': 'text/plain;charset=UTF-8' })
+        raise Error.new('Failed registering url for DOI', response) unless response.status == 201
+
+        url
+      end
+
+      class Error < RuntimeError
+        ##
+        # @!attribute [r] status
+        #   @return [Integer]
+        attr_reader :status
+
+        ##
+        # @param msg      [String]
+        # @param response [Faraday::Response]
+        def initialize(msg = '', response = nil)
+          if response
+            @status = response.status
+            msg += "\n#{@status}: #{response.reason_phrase}\n"
+            msg += response.body
+          end
+
+          super(msg)
+        end
+      end
+
+      private
+
+      def connection
+        Faraday.new(url: base_url) do |c|
+          c.basic_auth(username, password)
+          c.adapter(Faraday.default_adapter)
+        end
+      end
+
+      def mds_connection
+        Faraday.new(url: mds_base_url) do |c|
+          c.basic_auth(username, password)
+          c.adapter(Faraday.default_adapter)
+        end
+      end
+
+      def draft_doi_payload
+        {
+          "data": {
+            "type": "dois",
+            "attributes": {
+              "prefix": prefix
+            }
+          }
+        }
+      end
+
+      def base_url
+        mode == :production ? PRODUCTION_BASE_URL : TEST_BASE_URL
+      end
+
+      def mds_base_url
+        mode == :production ? PRODUCTION_MDS_BASE_URL : TEST_MDS_BASE_URL
+      end
+    end
+  end
+end

--- a/hyrax-doi.gemspec
+++ b/hyrax-doi.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency 'shoulda-matchers'
+  spec.add_development_dependency 'webmock'
   # Workaround for cc-test-reporter with SimpleCov 0.18.
   # Stop upgrading SimpleCov until the following issue will be resolved.
   # https://github.com/codeclimate/test-reporter/issues/418

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,9 @@ require 'factory_bot_rails'
 require 'rspec/rails'
 require 'active_fedora/cleaner'
 require 'noid/rails/rspec'
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
+
 # Add additional requires below this line. Rails is not loaded until this point!
 # For testing generators
 require 'ammeter/init'

--- a/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
@@ -19,7 +19,7 @@ describe Bolognese::Readers::HyraxWorkReader do
       creator: [creator],
       publisher: [publisher],
       description: [description],
-      doi: doi
+      doi: [doi]
     }
   end
   let(:title) { 'Moomin' }

--- a/spec/services/bolognese/writers/hyrax_work_writer_spec.rb
+++ b/spec/services/bolognese/writers/hyrax_work_writer_spec.rb
@@ -19,7 +19,7 @@ describe Bolognese::Writers::HyraxWorkWriter do
       creator: [creator],
       publisher: [publisher],
       description: [description],
-      doi: doi
+      doi: [doi]
     }
   end
   let(:title) { 'Moomin' }
@@ -52,7 +52,7 @@ describe Bolognese::Writers::HyraxWorkWriter do
       expect(new_hyrax_work.creator).to eq [creator]
       expect(new_hyrax_work.publisher).to eq [publisher]
       expect(new_hyrax_work.description).to eq [description]
-      expect(new_hyrax_work.doi).to eq doi
+      expect(new_hyrax_work.doi).to eq [doi]
     end
   end
 end

--- a/spec/services/hyrax/doi/datacite_client_spec.rb
+++ b/spec/services/hyrax/doi/datacite_client_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'support/datacite_api_stubs'
+
+describe 'Hyrax::DOI::DataciteClient', :datacite_api do
+  let(:client) { Hyrax::DOI::DataciteClient.new(username: username, password: password, prefix: prefix, mode: :test) }
+  let(:username) { 'username' }
+  let(:password) { 'password' }
+  let(:prefix) { '10.1234' }
+  let(:draft_doi) { "#{prefix}/draft-doi" }
+  let(:findable_doi) { "#{prefix}/findable-doi" }
+  let(:unknown_doi) { "#{prefix}/unknown-doi" }
+
+  describe '#create_draft_doi' do
+    it 'creates a DOI' do
+      expect(client.create_draft_doi).to match Hyrax::DOI::DOIBehavior::DOI_REGEX
+    end
+
+    context 'with incorrect credentials' do
+      let(:username) { 'bad-username' }
+      let(:password) { 'bad-password' }
+
+      it 'raises error with bad credentials' do
+        expect { client.create_draft_doi }.to raise_error(/Failed creating draft DOI/)
+      end
+    end
+  end
+
+  describe '#delete_draft_doi' do
+    it 'deletes a draft DOI' do
+      expect(client.delete_draft_doi(draft_doi)).to eq draft_doi
+    end
+
+    it 'errors with a registered or findable DOI' do
+      expect { client.delete_draft_doi(findable_doi) }.to raise_error(/Failed deleting draft DOI/)
+    end
+  end
+
+  describe '#get_metadata' do
+    it 'returns metadata' do
+      response = client.get_metadata(draft_doi)
+      expect(response).to be_a Nokogiri::XML::Document
+      expect(response.xpath('//identifier[@identifierType="DOI"]/text()').first.to_s).to eq draft_doi
+    end
+
+    it 'errors with unknown DOI' do
+      expect { client.get_metadata(unknown_doi) }.to raise_error(/Failed getting DOI metadata/)
+    end
+  end
+
+  describe '#put_metadata' do
+    let(:metadata) do
+      <<-XML.chomp
+        <?xml version="1.0" encoding="UTF-8"?>
+        <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
+          <identifier identifierType="DOI">#{doi}</identifier>
+          <creators>
+            <creator>
+              <creatorName>Chris Colvard</creatorName>
+            </creator>
+          </creators>
+          <titles>
+            <title>Test datacite registration work</title>
+          </titles>
+          <publisher>Ubiquity Press</publisher>
+          <publicationYear>2020</publicationYear>
+          <resourceType resourceTypeGeneral="Other">GenericWork</resourceType>
+          <sizes/>
+          <formats/>
+          <version/>
+        </resource>
+      XML
+    end
+    let(:doi) { draft_doi }
+
+    context 'when doi param is blank' do
+      let(:doi) { prefix }
+
+      it 'creates a doi' do
+        expect(client.put_metadata(nil, metadata)).to match Hyrax::DOI::DOIBehavior::DOI_REGEX
+      end
+    end
+
+    it 'returns the same doi' do
+      expect(client.put_metadata(draft_doi, metadata)).to eq draft_doi
+    end
+
+    context 'with unknown doi' do
+      let(:prefix) { 'unknown-prefix' }
+      it 'errors with unknown DOI' do
+        expect { client.put_metadata(unknown_doi, metadata) }.to raise_error(/Failed creating metadata for DOI/)
+      end
+    end
+  end
+
+  describe '#get_url' do
+    it 'returns url' do
+      expect(URI.parse(client.get_url(draft_doi))).to be_a URI::HTTP
+    end
+
+    it 'errors with unknown DOI' do
+      expect { client.get_url(unknown_doi) }.to raise_error(/Failed getting DOI url/)
+    end
+  end
+
+  describe '#register_url' do
+    let(:url) { 'https://www.moomin.com/en/' }
+
+    it 'returns the url when successful' do
+      expect(client.register_url(draft_doi, url)).to eq url
+    end
+
+    it 'errors with unknown DOI' do
+      expect { client.register_url(unknown_doi, url) }.to raise_error(/Failed registering url for DOI/)
+    end
+  end
+end

--- a/spec/support/datacite_api_stubs.rb
+++ b/spec/support/datacite_api_stubs.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.before(datacite_api: true) do
+    # POST <API_BASE>/.*
+    # Post bad credentials
+    stub_request(:post, /#{Regexp.quote(Hyrax::DOI::DataciteClient::TEST_BASE_URL)}.*/)
+      .with(headers: { "Content-Type" => "application/json" })
+      .to_return(status: 404, body: '{"errors":[{"status":"404","title":"The resource you are looking for doesn\'t exist."}]}')
+
+    # POST <API_BASE>/dois/
+    # Create draft doi
+    stub_request(:post, URI.join(Hyrax::DOI::DataciteClient::TEST_BASE_URL, "dois"))
+      .with(headers: { "Content-Type" => "application/json" },
+            basic_auth: ['username', 'password'],
+            body: "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"#{prefix}\"}}}")
+      .to_return(status: 201, body: "{\"data\":{\"id\":\"#{prefix}/draft-doi\",\"type\":\"dois\",\"attributes\":{\"doi\":\"#{prefix}/draft-doi\",\"prefix\":\"#{prefix}\",\"suffix\":\"draft-doi\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[],\"titles\":null,\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":null,\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-10T20:58:59.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-10T20:58:59.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"client-id\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"#{prefix}/draft-doi\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}")
+
+    # DELETE <MDS_BASE>/doi/<prefix>/draft-doi
+    # Delete draft doi
+    stub_request(:delete, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/draft-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 200, body: '{"errors":[{"status":"405", "title":"Method not allowed"}]}')
+
+    # DELETE <MDS_BASE>/doi/<prefix>/findable-doi
+    # Delete draft doi with findable doi
+    stub_request(:delete, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/findable-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 405, body: '{"errors":[{"status":"405", "title":"Method not allowed"}]}')
+
+    # GET <MDS_BASE>/metadata/<prefix>/draft-doi
+    # Get doi metadata
+    stub_request(:get, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "metadata/#{prefix}/draft-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 200, body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <resource xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://datacite.org/schema/kernel-4\" xsi:schemaLocation=\"http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd\">
+      <identifier identifierType=\"DOI\">#{prefix}/draft-doi</identifier>
+      <creators>
+        <creator>
+          <creatorName>Chris Colvard</creatorName>
+        </creator>
+      </creators>
+      <titles>
+        <title>Test datacite registration work</title>
+      </titles>
+      <publisher>Ubiquity Press</publisher>
+      <publicationYear>2020</publicationYear>
+      <resourceType resourceTypeGeneral=\"Other\">GenericWork</resourceType>
+      <sizes/>
+      <formats/>
+      <version/>
+    </resource>")
+
+    # GET <MDS_BASE>/metadata/<prefix>/unknown-doi
+    # Get doi metadata with unknown doi
+    stub_request(:get, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "metadata/#{prefix}/unknown-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 404, body: 'DOI is unknown to MDS')
+
+    # PUT <MDS_BASE>/metadata/<prefix>
+    # Create new draft doi with metadata
+    stub_request(:put, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "metadata/#{prefix}"))
+      .with(headers: { 'Content-Type': 'application/xml;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 201, body: "OK (#{prefix}/draft-doi)")
+
+    # PUT <MDS_BASE>/metadata/<prefix>/draft-doi
+    # Update metadata for draft doi
+    stub_request(:put, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "metadata/#{prefix}/draft-doi"))
+      .with(headers: { 'Content-Type': 'application/xml;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 201, body: "OK (#{prefix}/draft-doi)")
+
+    # PUT <MDS_BASE>/metadata/unknown-prefix/unknown-doi
+    # Update metadata for unknown doi
+    stub_request(:put, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "metadata/unknown-prefix/unknown-doi"))
+      .with(headers: { 'Content-Type': 'application/xml;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 403, body: 'Access is denied')
+
+    # GET <MDS_BASE>/doi/<prefix>/draft-doi
+    # Get doi url
+    stub_request(:get, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/draft-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 200, body: "https://www.moomin.com/en/")
+
+    # GET <MDS_BASE>/doi/<prefix>/unknown-doi
+    # Get doi url with unknown doi
+    stub_request(:get, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/unknown-doi"))
+      .with(basic_auth: ['username', 'password'])
+      .to_return(status: 404, body: "DOI is unknown to MDS")
+
+    # PUT <MDS_BASE>/doi/<prefix>/draft-doi
+    # Update url for draft doi
+    stub_request(:put, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/draft-doi"))
+      .with(headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 201, body: "")
+
+    # PUT <MDS_BASE>/doi/<prefix>/unknown-doi
+    # Update url for unknown doi
+    stub_request(:put, URI.join(Hyrax::DOI::DataciteClient::TEST_MDS_BASE_URL, "doi/#{prefix}/unknown-doi"))
+      .with(headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 422, body: "Can't be blank")
+  end
+end


### PR DESCRIPTION
Draft DOIs are created using the REST API while all other calls go to
the MDS API.

DOI state management is not fully supported yet and will need
improvements.

This PR tests using webmock but it might be good in the future to add integration tests which actually spin up datacite's api container(s) (at least in the CI environment). (See [lupo](https://github.com/datacite/lupo) and [poodle](https://github.com/datacite/poodle))