### PR TITLE
Separate DataCite specific behavior out to a separate module

### DIFF
--- a/app/actors/hyrax/actors/doi_actor.rb
+++ b/app/actors/hyrax/actors/doi_actor.rb
@@ -37,13 +37,21 @@ module Hyrax
 
       def create_or_update_doi(work)
         return true unless doi_enabled_work_type?(work)
-        # TODO: Add more gate keeping?
-        Hyrax::DOI::RegisterDOIJob.perform_later(work)
+
+        Hyrax::DOI::RegisterDOIJob.perform_later(work, registrar: find_registrar(work), registrar_opts: work.doi_registrar_opts)
       end
 
       # Check if work is DOI enabled
       def doi_enabled_work_type?(work)
         work.class.ancestors.include? Hyrax::DOI::DOIBehavior
+      end
+
+      def find_registrar(work)
+        # Ensure that registrar is a string because ActiveJob cannot serialize a symbol
+        # Do this as a two step process because nil.to_s is ""
+        # which causes the job not to fallback to its default
+        registrar_name = work.doi_registrar
+        registrar_name.present? ? registrar_name.to_s : nil
       end
     end
   end

--- a/app/models/concerns/hyrax/doi/datacite_doi_behavior.rb
+++ b/app/models/concerns/hyrax/doi/datacite_doi_behavior.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Hyrax
+  module DOI
+    module DataCiteDOIBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        property :doi_status_when_public, predicate: ::RDF::URI('http://samvera.org/ns/hyrax/doi#doi_status_when_public'), multiple: false do |index|
+          index.as :stored_sortable
+        end
+
+        # TODO: turn controlled vocab here into a frozen constant to allow for extensions and reuse
+        validates :doi_status_when_public, inclusion: { in: [:draft, :registered, :findable] }, allow_nil: true
+      end
+
+      # Override
+      def doi_registrar
+        :datacite
+      end
+    end
+  end
+end

--- a/app/models/concerns/hyrax/doi/doi_behavior.rb
+++ b/app/models/concerns/hyrax/doi/doi_behavior.rb
@@ -10,13 +10,20 @@ module Hyrax
         property :doi, predicate: ::RDF::Vocab::BIBO.doi, multiple: true do |index|
           index.as :stored_sortable
         end
-        property :doi_status_when_public, predicate: ::RDF::URI('http://samvera.org/ns/hyrax/doi#doi_status_when_public'), multiple: false do |index|
-          index.as :stored_sortable
-        end
 
         validate :validate_doi
-        # TODO: turn controlled vocab here into a frozen constant to allow for extensions and reuse
-        validates :doi_status_when_public, inclusion: { in: [:draft, :registered, :findable] }, allow_nil: true
+      end
+
+      # Override this method
+      # Specify a registrar to use with this class
+      def doi_registrar
+        nil
+      end
+
+      # Override this method
+      # Specify options for the registrar to use with this class
+      def doi_registrar_opts
+        {}
       end
 
       private

--- a/lib/hyrax/doi/engine.rb
+++ b/lib/hyrax/doi/engine.rb
@@ -9,6 +9,7 @@ module Hyrax
         # With this hyrax/doi/application_helper -> Hyrax::DOI::ApplicationHelper
         ActiveSupport::Inflector.inflections(:en) do |inflect|
           inflect.acronym 'DOI'
+          inflect.acronym 'DataCite'
         end
       end
 

--- a/lib/hyrax/doi/spec/shared_specs.rb
+++ b/lib/hyrax/doi/spec/shared_specs.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
 require 'hyrax/doi/spec/shared_specs/doi_behavior'
+require 'hyrax/doi/spec/shared_specs/datacite_doi_behavior'

--- a/lib/hyrax/doi/spec/shared_specs/datacite_doi_behavior.rb
+++ b/lib/hyrax/doi/spec/shared_specs/datacite_doi_behavior.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+RSpec.shared_examples "a DataCite DOI-enabled model" do
+  subject { work }
+
+  let(:properties) do
+    [:doi_status_when_public]
+  end
+
+  describe "properties" do
+    it "has DataCite DOI properties" do
+      properties.each do |property|
+        expect(subject).to respond_to(property)
+      end
+    end
+  end
+
+  describe 'validations' do
+    it 'validates inclusion of doi_status_when_public' do
+      expect(subject).to validate_inclusion_of(:doi_status_when_public).in_array([nil, :draft, :registered, :findable]).allow_nil
+    end
+  end
+
+  describe 'to_solr' do
+    let(:solr_doc) { subject.to_solr }
+
+    let(:solr_fields) do
+      [:doi_status_when_public_ssi]
+    end
+
+    before do
+      work.doi_status_when_public = :draft
+    end
+
+    it 'has solr fields' do
+      solr_fields.each do |field|
+        expect(solr_doc.fetch(field.to_s)).not_to be_blank
+      end
+    end
+  end
+end

--- a/lib/hyrax/doi/spec/shared_specs/doi_behavior.rb
+++ b/lib/hyrax/doi/spec/shared_specs/doi_behavior.rb
@@ -3,8 +3,7 @@ RSpec.shared_examples "a DOI-enabled model" do
   subject { work }
 
   let(:properties) do
-    [:doi,
-     :doi_status_when_public]
+    [:doi]
   end
 
   describe "properties" do
@@ -32,28 +31,32 @@ RSpec.shared_examples "a DOI-enabled model" do
         end
       end
     end
-
-    it 'validates inclusion of doi_status_when_public' do
-      expect(subject).to validate_inclusion_of(:doi_status_when_public).in_array([nil, :draft, :registered, :findable]).allow_nil
-    end
   end
 
   describe 'to_solr' do
     let(:solr_doc) { subject.to_solr }
 
     let(:solr_fields) do
-      [:doi_ssi,
-       :doi_status_when_public_ssi]
+      [:doi_ssi]
     end
 
     before do
       work.doi = ["10.1234/abc"]
-      work.doi_status_when_public = :draft
     end
 
     it 'has solr fields' do
       solr_fields.each do |field|
         expect(solr_doc.fetch(field.to_s)).not_to be_blank
+      end
+    end
+  end
+
+  describe 'methods' do
+    let(:methods) { [:doi_registrar, :doi_registrar_opts] }
+
+    it "has DOI methods" do
+      properties.each do |property|
+        expect(subject).to respond_to(property)
       end
     end
   end

--- a/spec/jobs/hyrax/doi/register_doi_job_spec.rb
+++ b/spec/jobs/hyrax/doi/register_doi_job_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Hyrax::DOI::RegisterDOIJob, type: :job do
   let(:model_class) do
     Class.new(GenericWork) do
       include Hyrax::DOI::DOIBehavior
-
-      def registrar_name
-        :moomin
-      end
     end
   end
   let(:work) { model_class.create(title: ['Moomin']) }

--- a/spec/models/concerns/datacite_doi_behavior_spec.rb
+++ b/spec/models/concerns/datacite_doi_behavior_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hyrax/doi/spec/shared_specs'
+
+describe 'Hyrax::DOI::DataCiteDOIBehavior' do
+  let(:model_class) do
+    Class.new(GenericWork) do
+      include Hyrax::DOI::DOIBehavior
+      include Hyrax::DOI::DataCiteDOIBehavior
+
+      # Defined here for ActiveModel::Validations error messages
+      def self.name
+        "WorkWithDataCiteDOI"
+      end
+    end
+  end
+  let(:work) { model_class.new(title: ['Moomin']) }
+
+  it_behaves_like 'a DOI-enabled model'
+  it_behaves_like 'a DataCite DOI-enabled model'
+
+  describe '#doi_registrar' do
+    it 'returns :datacite' do
+      expect(work.doi_registrar).to eq :datacite
+    end
+  end
+end


### PR DESCRIPTION
This isolates the DataCite specific behavior allowing it to be more focused and opinionated.
Alternatively other registrar-specific behavior can be mixed into models if DataCite isn't wanted.

Future work: add option to generator to inject DataCite behavior and setup an initializer (https://guides.rubyonrails.org/generators.html#adding-command-line-arguments)