### PR TITLE
Use official bolognese release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-gem 'bolognese', git: 'https://github.com/cjcolvar/bolognese.git', branch: 'cjcolvar-patch-1'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,8 @@
-GIT
-  remote: https://github.com/cjcolvar/bolognese.git
-  revision: ea1a794f132bd3458e554985533efc12ec4db75d
-  branch: cjcolvar-patch-1
-  specs:
-    bolognese (1.8.5)
-      activesupport (>= 4.2.5)
-      benchmark_methods (~> 0.7)
-      bibtex-ruby (>= 5.1.0)
-      builder (~> 3.2, >= 3.2.2)
-      citeproc-ruby (~> 1.1, >= 1.1.12)
-      colorize (~> 0.8.1)
-      concurrent-ruby (~> 1.1, >= 1.1.5)
-      csl-styles (~> 1.0, >= 1.0.1.10)
-      edtf (~> 3.0, >= 3.0.4)
-      faraday (~> 0.17.3)
-      gender_detector (~> 0.1.2)
-      iso8601 (~> 0.9.1)
-      json-ld-preloaded (~> 3.1, >= 3.1.3)
-      jsonlint (~> 0.3.0)
-      loofah (~> 2.0, >= 2.0.3)
-      maremma (>= 4.7, < 5)
-      namae (~> 1.0)
-      nokogiri (~> 1.10.4)
-      oj (~> 3.10)
-      oj_mimic_json (~> 1.0, >= 1.0.1)
-      postrank-uri (~> 1.0, >= 1.0.18)
-      rdf-rdfxml (~> 3.1)
-      rdf-turtle (~> 3.1)
-      thor (>= 0.19)
-
 PATH
   remote: .
   specs:
     hyrax-doi (0.1.0)
-      bolognese (~> 1.8)
+      bolognese (~> 1.8, >= 1.8.6)
       hyrax (~> 2.9)
       rails (~> 5.2.4, >= 5.2.4.3)
 
@@ -170,6 +139,31 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
+    bolognese (1.8.6)
+      activesupport (>= 4.2.5)
+      benchmark_methods (~> 0.7)
+      bibtex-ruby (>= 5.1.0)
+      builder (~> 3.2, >= 3.2.2)
+      citeproc-ruby (~> 1.1, >= 1.1.12)
+      colorize (~> 0.8.1)
+      concurrent-ruby (~> 1.1, >= 1.1.5)
+      csl-styles (~> 1.0, >= 1.0.1.10)
+      edtf (~> 3.0, >= 3.0.4)
+      faraday (~> 0.17.3)
+      gender_detector (~> 0.1.2)
+      iso8601 (~> 0.9.1)
+      json-ld-preloaded (~> 3.1, >= 3.1.3)
+      jsonlint (~> 0.3.0)
+      loofah (~> 2.0, >= 2.0.3)
+      maremma (>= 4.7, < 5)
+      namae (~> 1.0)
+      nokogiri (~> 1.10.4)
+      oj (~> 3.10)
+      oj_mimic_json (~> 1.0, >= 1.0.1)
+      postrank-uri (~> 1.0, >= 1.0.18)
+      rdf-rdfxml (~> 3.1)
+      rdf-turtle (~> 3.1)
+      thor (>= 0.19)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -220,7 +214,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -946,7 +940,6 @@ PLATFORMS
 DEPENDENCIES
   ammeter
   bixby
-  bolognese!
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.0)
   byebug

--- a/hyrax-doi.gemspec
+++ b/hyrax-doi.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hyrax", "~> 2.9"
 
-  spec.add_dependency "bolognese", "~> 1.8"
+  spec.add_dependency "bolognese", "~> 1.8", ">= 1.8.6"
 
   spec.add_development_dependency 'ammeter'
   spec.add_development_dependency "bixby"


### PR DESCRIPTION
I had to fork `bolognese` in order to relax its restrictions on `thor` versions to avoid conflicts with the `thor` restrictions coming from various samvera components.  `bolognese` 1.8.6 has the relaxed `thor` dependency restrictions so we can drop the fork now.