### PR TITLE
Use Hyrax's ingest queue

### DIFF
--- a/app/jobs/hyrax/doi/register_doi_job.rb
+++ b/app/jobs/hyrax/doi/register_doi_job.rb
@@ -2,7 +2,7 @@
 module Hyrax
   module DOI
     class RegisterDOIJob < ApplicationJob
-      queue_as :doi_service
+      queue_as Hyrax.config.ingest_queue_name
 
       ##
       # @param model [ActiveFedora::Base]

--- a/spec/actors/hyrax/actors/doi_actor_spec.rb
+++ b/spec/actors/hyrax/actors/doi_actor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::Actors::DOIActor do
       expect { actor.create(env) }
         .to have_enqueued_job(Hyrax::DOI::RegisterDOIJob)
         .with(work, registrar: nil, registrar_opts: {})
-        .on_queue('doi_service')
+        .on_queue(Hyrax.config.ingest_queue_name)
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe Hyrax::Actors::DOIActor do
       expect { actor.create(env) }
         .to have_enqueued_job(Hyrax::DOI::RegisterDOIJob)
         .with(work, registrar: nil, registrar_opts: {})
-        .on_queue('doi_service')
+        .on_queue(Hyrax.config.ingest_queue_name)
     end
 
     context 'when the work implements registrar_name and registrar_opts' do
@@ -81,7 +81,7 @@ RSpec.describe Hyrax::Actors::DOIActor do
         expect { actor.create(env) }
           .to have_enqueued_job(Hyrax::DOI::RegisterDOIJob)
           .with(work, registrar: 'moomin', registrar_opts: { prefix: '10.9999' })
-          .on_queue('doi_service')
+          .on_queue(Hyrax.config.ingest_queue_name)
       end
     end
   end

--- a/spec/jobs/hyrax/doi/register_doi_job_spec.rb
+++ b/spec/jobs/hyrax/doi/register_doi_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::DOI::RegisterDOIJob, type: :job do
       expect { described_class.perform_later(work) }
         .to enqueue_job(described_class)
         .with(work)
-        .on_queue('doi_service')
+        .on_queue(Hyrax.config.ingest_queue_name)
     end
   end
 


### PR DESCRIPTION
This will allow it to be configurable and match the other jobs spawned from the actor stack. This should also ensure that sidekiq is configured to handle this queue.