### PR TITLE
Show DOI on work show page

### DIFF
--- a/app/helpers/hyrax/doi/helper_behavior.rb
+++ b/app/helpers/hyrax/doi/helper_behavior.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Hyrax
+  module DOI
+    module HelperBehavior
+      include Hyrax::DOI::WorkFormHelper
+      include Hyrax::DOI::WorkShowHelper
+    end
+  end
+end

--- a/app/helpers/hyrax/doi/work_show_helper.rb
+++ b/app/helpers/hyrax/doi/work_show_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Hyrax
+  module DOI
+    module WorkShowHelper
+      def render_doi?(presenter)
+        return false unless presenter.class.ancestors.include? Hyrax::DOI::DOIPresenterBehavior
+        return presenter.doi_status_when_public.in? [nil, 'registered', 'findable'] if presenter.class.ancestors.include? Hyrax::DOI::DataCiteDOIPresenterBehavior
+        true
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/hyrax/doi/doi_presenter_behavior.rb
+++ b/app/presenters/concerns/hyrax/doi/doi_presenter_behavior.rb
@@ -4,10 +4,8 @@ module Hyrax
     module DOIPresenterBehavior
       extend ActiveSupport::Concern
 
-      delegate :doi, to: :solr_document
-
-      def doi_link
-        doi.present? ? "https://doi.org/#{doi}" : nil
+      def doi
+        solr_document.doi.present? ? "https://doi.org/#{solr_document.doi}" : nil
       end
     end
   end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,0 +1,18 @@
+<%# Overridden to display doi attribute (Copied here from Hyrax 2.9) %>
+<%# _attribute_rows.html.erb is likely to be overridden per work type so this provides a %>
+<%# simple out of the box way to show the doi while not impedeing those who choose to customize %>
+<%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
+<%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
+<%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>
+<%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:source, html_dl: true) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+<%= presenter.attribute_to_html(:doi, render_as: :external_link, html_dl: true) if respond_to?(:render_doi?) && render_doi?(presenter) %>

--- a/lib/generators/hyrax/doi/install_generator.rb
+++ b/lib/generators/hyrax/doi/install_generator.rb
@@ -36,8 +36,8 @@ module Hyrax
 
         insert_into_file helper_file, after: 'include Hyrax::HyraxHelperBehavior' do
           "\n" \
-          "  # Overrides #form_tabs_for for DOI tab provided by hyrax-doi plugin.\n" \
-          "  include Hyrax::DOI::WorkFormHelper"
+          "  # Helpers provided by hyrax-doi plugin.\n" \
+          "  include Hyrax::DOI::HelperBehavior"
         end
       end
 

--- a/lib/hyrax/doi/engine.rb
+++ b/lib/hyrax/doi/engine.rb
@@ -19,6 +19,9 @@ module Hyrax
         require 'bolognese'
         Bolognese::Metadata.prepend Bolognese::Readers::HyraxWorkReader
         Bolognese::Metadata.prepend Bolognese::Writers::HyraxWorkWriter
+
+        # Prepend our views so they have precedence
+        ActionController::Base.prepend_view_path(paths['app/views'].existent)
       end
     end
   end

--- a/lib/hyrax/doi/spec/shared_specs/doi_presenter_behavior.rb
+++ b/lib/hyrax/doi/spec/shared_specs/doi_presenter_behavior.rb
@@ -5,9 +5,7 @@ RSpec.shared_examples "a DOI-enabled presenter" do
   let(:presenter) { presenter_class.new(solr_document, nil, nil) }
   let(:solr_document) { instance_double(solr_document_class) }
 
-  it { is_expected.to delegate_method(:doi).to(:solr_document) }
-
-  describe 'doi_link' do
+  describe 'doi' do
     let(:doi) { '10.1234/abc' }
 
     before do
@@ -15,7 +13,7 @@ RSpec.shared_examples "a DOI-enabled presenter" do
     end
 
     it 'returns a doi url' do
-      expect(subject.doi_link).to eq "https://doi.org/#{subject.doi}"
+      expect(subject.doi).to eq "https://doi.org/#{subject.solr_document.doi}"
     end
   end
 end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -33,7 +33,7 @@ describe Hyrax::DOI::InstallGenerator, type: :generator do
   describe 'inject_into_helper' do
     it 'adds behavior module to helper' do
       run_generator
-      expect(file(helper_path)).to contain('include Hyrax::DOI::WorkFormHelper')
+      expect(file(helper_path)).to contain('include Hyrax::DOI::HelperBehavior')
     end
   end
 

--- a/spec/helpers/work_show_helper_spec.rb
+++ b/spec/helpers/work_show_helper_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'Hyrax::DOI::WorkFormHelper' do
+  describe 'render_doi?' do
+    let(:doi_presenter_class) do
+      Class.new(Hyrax::GenericWorkPresenter) do
+        include Hyrax::DOI::DOIPresenterBehavior
+      end
+    end
+    let(:datacite_presenter_class) do
+      Class.new(Hyrax::GenericWorkPresenter) do
+        include Hyrax::DOI::DOIPresenterBehavior
+        include Hyrax::DOI::DataCiteDOIPresenterBehavior
+      end
+    end
+    let(:non_doi_presenter_class) { Hyrax::GenericWorkPresenter }
+    let(:solr_document_class) do
+      Class.new(SolrDocument) do
+        include Hyrax::DOI::SolrDocument::DOIBehavior
+        include Hyrax::DOI::SolrDocument::DataCiteDOIBehavior
+      end
+    end
+    let(:presenter) { presenter_class.new(solr_document, nil, nil) }
+    let(:solr_document) { instance_double(solr_document_class) }
+
+    # Override rspec-rails defined helper
+    # This allow us to inject HyraxHelper which is being overriden
+    # so super is defined.
+    let(:helper) do
+      _view.tap do |v|
+        v.extend(ApplicationHelper)
+        v.extend(HyraxHelper)
+        v.extend(Hyrax::DOI::HelperBehavior)
+        v.assign(view_assigns)
+      end
+    end
+
+    context 'with a DOI-enabled model' do
+      let(:presenter_class) { doi_presenter_class }
+
+      it 'returns true' do
+        expect(helper.render_doi?(presenter)).to eq true
+      end
+    end
+
+    context 'with a DataCite DOI-enabled presenter' do
+      let(:presenter_class) { datacite_presenter_class }
+
+      context 'with findable doi status' do
+        before do
+          allow(solr_document).to receive(:doi_status_when_public).and_return('findable')
+        end
+
+        it 'returns true' do
+          expect(helper.render_doi?(presenter)).to eq true
+        end
+      end
+
+      context 'with draft doi status' do
+        before do
+          allow(solr_document).to receive(:doi_status_when_public).and_return('draft')
+        end
+
+        it 'returns false' do
+          expect(helper.render_doi?(presenter)).to eq false
+        end
+      end
+
+      context 'with doi status not set' do
+        before do
+          allow(solr_document).to receive(:doi_status_when_public).and_return(nil)
+        end
+
+        it 'returns true' do
+          expect(helper.render_doi?(presenter)).to eq true
+        end
+      end
+    end
+
+    context 'with a non-DOI-enabled model' do
+      let(:presenter_class) { non_doi_presenter_class }
+
+      it 'returns false' do
+        expect(helper.render_doi?(presenter)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Override _attribute_rows partial to add DOI attribute.  In support of this effort, this PR does the following:
- Adds #render_doi? helper method
- Refactors helper injection to inject new parent helper module Hyrax::DOI::HelperBehavior
- Removed #doi delegation in presenter and renames #doi_link as #doi (because we should [always display a DOI as a link](https://support.datacite.org/docs/datacite-doi-display-guidelines#display-datacite-dois-as-a-complete-link))
- Prepends our views on the view_path so they can override Hyrax's views