### PR TITLE
Form validations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,6 @@ RSpec/AnyInstance:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/features/**/*'
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/app/services/bolognese/readers/hyrax_work_reader.rb
+++ b/app/services/bolognese/readers/hyrax_work_reader.rb
@@ -74,11 +74,10 @@ module Bolognese
       end
 
       def read_hyrax_work_publication_year(meta)
-        # FIXME: better parsing of free text dates...maybe using EDTF?
         date = meta.fetch("date_created", nil)&.first
         date ||= meta.fetch("date_uploaded", nil)
-        Date.parse(date.to_s).year
-      rescue Date::Error
+        Date.edtf(date.to_s).year
+      rescue StandardError
         Time.zone.today.year
       end
 
@@ -92,6 +91,7 @@ module Bolognese
 
       def read_hyrax_work_publisher(meta)
         # Fallback to ':unav' since this is a required field for datacite
+        # TODO: Should this default to application_name?
         parse_attributes(meta.fetch("publisher")).to_s.strip.presence || ":unav"
       end
     end

--- a/app/views/hyrax/base/_form_doi.html.erb
+++ b/app/views/hyrax/base/_form_doi.html.erb
@@ -1,22 +1,31 @@
+<%# TODO: determine these from actual DataCite data instead of the intention field stored in fedora %>
+<% disable_do_not_mint = @curation_concern.doi_status_when_public != nil %>
+<% disable_draft = @curation_concern.doi_status_when_public.in?(['registered','findable']) %>
+
 <div>
   <%# Render DOI input as a single field even though it is stored as multivalued %>
   <%= f.input :doi, input_html: { value: @curation_concern.doi.first,
                                   name: "#{f.object.model_name.param_key}[doi][]",
                                   style: "max-width: 40em" } %>
 
-  <%= link_to "Create draft DOI",
-              Hyrax::DOI::Engine.routes.url_helpers.create_draft_doi_path,
-              remote: true,
-              method: :get,
-              data: {
-                disable_with: "Creating draft DOI...",
-                params: {
-                  curation_concern: curation_concern.class.name.underscore,
-                  attribute: 'doi'
-                }
-              },
-              class: 'btn btn-default',
-              id: 'doi-create-draft-btn' %>
+  <%# Only show an actionable button if the work doesn't have a DOI already %>
+  <% if @curation_concern.doi.blank? %>
+    <%= link_to "Create draft DOI",
+                Hyrax::DOI::Engine.routes.url_helpers.create_draft_doi_path,
+                remote: true,
+                method: :get,
+                data: {
+                  disable_with: "Creating draft DOI...",
+                  params: {
+                    curation_concern: @curation_concern.class.name.underscore,
+                    attribute: 'doi'
+                  }
+                },
+                class: 'btn btn-default',
+                id: 'doi-create-draft-btn' %>
+  <% else %>
+    <div id='doi-create-draft-btn' class='btn btn-default' disabled>Create draft DOI</div>
+  <% end %>
 
   <%= link_to "Autofill form",
               Hyrax::DOI::Engine.routes.url_helpers.autofill_path,
@@ -37,11 +46,11 @@
 
     <div class="form-group" style="margin-left: 20px">
       <label class="radio" style="font-weight: normal">
-        <%= f.radio_button :doi_status_when_public, '', style: 'margin-top: 0px;' %>
+        <%= f.radio_button :doi_status_when_public, '', disabled: disable_do_not_mint, style: 'margin-top: 0px;' %>
         Do not mint
       </label>
       <label class="radio" style="font-weight: normal">
-        <%= f.radio_button :doi_status_when_public, 'draft', style: 'margin-top: 0px;' %>
+        <%= f.radio_button :doi_status_when_public, 'draft', disabled: disable_draft, style: 'margin-top: 0px;' %>
         Draft
       </label>
       <label class="radio" style="font-weight: normal">
@@ -72,4 +81,29 @@
   $("#doi-autofill-btn").on("ajax:error", function(e, xhr, status, error) {
     alert(xhr.responseText);
   });
+
+  // Force the user to confirm using fallback defaults when DataCite mandatory fields
+  // not filled in on the deposit form.  This only applies when the DOI is set to become
+  // registered or findable.  Let drafts be drafts.
+  document.getElementById('with_files_submit').addEventListener("click", function(event){
+    if (["findable", "registered"].indexOf(document.querySelector('input[name="generic_work[doi_status_when_public]"]:checked').value) < 0)
+      return;
+
+    const empty_fields = [];
+    if (document.querySelector('.generic_work_title .form-control').value == "")
+      empty_fields.push("Title")
+    if (document.querySelector('.generic_work_creator .form-control').value == "")
+      empty_fields.push("Creator")
+    if (document.querySelector('.generic_work_publisher .form-control').value == "")
+      empty_fields.push("Publisher")
+    if (document.querySelector('.generic_work_date_created .form-control').value == "")
+      empty_fields.push("Date Created")
+    if (empty_fields.length == 0)
+      return;
+
+    if(!window.confirm("DataCite DOI mandatory fields ("+ empty_fields.join(', ') +") are missing.  Placeholder values will be submitted to DataCite instead.  Do you want to proceed?")){
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }, false);
 </script>

--- a/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
@@ -96,8 +96,16 @@ describe Bolognese::Readers::HyraxWorkReader do
             work.date_uploaded = upload_date
           end
 
-          it 'prefers date_created' do
+          it 'sets year from date_created' do
             expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq "1945"
+          end
+
+          context 'with only year' do
+            let(:create_date) { '1945' }
+
+            it 'sets year from date_created' do
+              expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq "1945"
+            end
           end
         end
 
@@ -106,7 +114,7 @@ describe Bolognese::Readers::HyraxWorkReader do
             work.date_uploaded = upload_date
           end
 
-          it 'users date_uploaded' do
+          it 'sets year from date_uploaded' do
             expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq "2009"
           end
         end


### PR DESCRIPTION
This PR adds a confirmation dialog that appears if the DOI status is set to Registered or Findable and DataCite mandatory fields are missing.  The dialog forces the user to acknowledge that they are missing information and that defaults or placeholder values will be sent to DataCite.

Also added in this PR:
- Improved date parsing using EDTF (brought in by `bolognese`)
- Disabling of DOI status options based upon DOI status on page load
- Disabling of Create draft DOI button if work has DOI on page load

I didn't add a feature test for the form validation confirmation dialog.  This may want to be added in the future but I skipped due to potential complexity and in the interest of time.